### PR TITLE
Fixing get-text: no longer eats newlines.

### DIFF
--- a/src/cljs/enfocus/core.cljs
+++ b/src/cljs/enfocus/core.cljs
@@ -515,7 +515,9 @@
           content (flatten (map html (if (map? m) ms more)))
           node (.createElement js/document tag-name)]
       (doseq [[key val] attrs]
-        (.setAttribute node (name key) val))
+        (if (= 0 (.indexOf (name key) "on"))
+          (aset node (name key) val) ;;set event handlers
+          (.setAttribute node (name key) val)))
       (when content (domina/append! node content)))
     (sequential? node-spec) (flatten (map html node-spec))
     :else (.createTextNode js/document (str node-spec))))

--- a/test/cljs/enfocus/events_test.cljs
+++ b/test/cljs/enfocus/events_test.cljs
@@ -83,3 +83,14 @@
           "#test-btn" (remove-listeners :click)
           "#test-btn" simulate-click-event)
       (is (= "success" @atm)))))
+
+
+(deftest html-event-handlers-test
+  (testing "html function allows binding of event handlers"
+    (let [atm (atom "fail")]
+      (at "#test-id"
+              (content
+               (html [:button {:id "test-btn"
+                               :onclick #(reset! atm "success")}])))
+      (at "#test-btn" simulate-click-event)
+      (is (= "success" @atm)))))


### PR DESCRIPTION
get-text using Google Closure kills newlines. With newline-sensitive text and markup like Textile, this is a problem. Using .-textContent instead fixes this problem.